### PR TITLE
Update preflight checks to automate release

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,7 @@ also run `bin/console` for an interactive prompt that will allow you to experime
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the
 version number in `version.rb`, ensure the CHANGELOG.md is updated and that everything is committed.
-Then run `bundle exec rake release`, which will create a git tag for the version,  push git commits and tags, and push
-the `.gem` file to [rubygems.org](https://rubygems.org).
+Then run `bundle exec rake release`, which will create a git tag for the version, then push git commits and tags to GitHub.
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # We add preflight to the release task pre-requisites before loading in the
-# bundler/gem_tasks to ensure that it runs first. This is becuase 'release' is
+# bundler/gem_tasks to ensure that it runs first. This is because 'release' is
 # actually composed entirely of pre-requisites and so would otherwise end up
 # running the pre-flight tasks AFTER everything else
 task release: :preflight
@@ -25,7 +25,7 @@ task :preflight do
   puts
   puts "☐ lib/record_loader/version.rb updated? Currently contains #{current_version}"
   puts '☐ CHANGELOG.md updated'
-  puts '☐ Commited, on master and up to date'
+  puts '☐ Committed, on master and up to date'
   puts
   print 'Proceed Y/N > '
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,8 +7,11 @@
 task release: :preflight
 
 require 'bundler/gem_tasks'
+require 'rainbow/refinement'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
+
+using Rainbow
 
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new
@@ -17,17 +20,25 @@ task default: %i[rubocop spec]
 
 desc 'Runs the preflight checklist before building a release'
 task :preflight do
-  puts '🛫 Preflight checklist'
+  puts '──────────────────────'.bright
+  puts '🛫 Preflight checklist'.bright
+  puts '──────────────────────'.bright
 
   current_version = RecordLoader::VERSION
+  latest_changelog_entry = File.read('CHANGELOG.md').scan(/^## \[(.*?)\]/).flatten.first
+  latest_master = latest_master?
 
-  puts 'This is still a manual process, but before we roll a release, lets confirm a few things:'
+  puts 'Before we roll a release, lets confirm a few things:'
   puts
-  puts "☐ lib/record_loader/version.rb updated? Currently contains #{current_version}"
-  puts '☐ CHANGELOG.md updated'
-  puts '☐ Committed, on master and up to date'
+  puts "▢ Has the gem version been updated? Currently #{st(current_version)} in #{p('lib/record_loader/version.rb')} "
+  puts "▢ Has the changelog been updated? Latest entry is #{st(latest_changelog_entry)} in #{p('CHANGELOG.md')}"
+  puts "▢ Are all changes committed to git? #{yn(uncommitted_changes?)}"
+  puts "▢ Are you on master and up to date? #{yn(on_master? & latest_master)}"
   puts
-  print 'Proceed Y/N > '
+  puts 'Proceeding will package the gem, create a git tag for the version, push commits and tags to GitHub, and push the .gem file to rubygems.org.'.italic
+  puts 'We do not currently have an accessible team account on rubygems.org, so this final step can be skipped.'.italic
+  puts
+  print 'Proceed [y/N] > '
 
   proceed = $stdin.gets.chomp
 
@@ -37,4 +48,35 @@ task :preflight do
     puts 'Canceling release process'
     exit 1
   end
+end
+
+private
+
+# Highlight the provided path in cyan for better visibility in the terminal
+def p(path)
+  Rainbow(path).bright.cyan
+end
+
+# Highlight the provided status in white for better visibility in the terminal
+def st(status)
+  Rainbow(status).bright.white
+end
+
+# Given a boolean value, return Yes or No, or 'N/A' if the value is nil
+def yn(value)
+  return 'N/A' if value.nil?
+
+  value ? 'Yes'.bright.green : 'No'.bright.red
+end
+
+def uncommitted_changes?
+  `git status --porcelain`.empty?
+end
+
+def on_master?
+  `git rev-parse --abrev-ref HEAD`.chomp == 'master'
+end
+
+def latest_master?
+  !`git remote show origin | grep "pushes to master" | grep "(up to date)"`.empty?
 end

--- a/Rakefile
+++ b/Rakefile
@@ -57,9 +57,9 @@ def p(path)
   Rainbow(path).bright.cyan
 end
 
-# Highlight the provided status in white for better visibility in the terminal
+# Highlight the provided status in bright for better visibility in the terminal
 def st(status)
-  Rainbow(status).bright.white
+  Rainbow(status).bright
 end
 
 # Given a boolean value, return Yes or No, or 'N/A' if the value is nil

--- a/Rakefile
+++ b/Rakefile
@@ -35,7 +35,8 @@ task :preflight do
   puts "▢ Are all changes committed to git? #{yn(uncommitted_changes?)}"
   puts "▢ Are you on master and up to date? #{yn(on_master? & latest_master)}"
   puts
-  puts 'Proceeding will package the gem, create a git tag for the version, push commits and tags to GitHub, and push the .gem file to rubygems.org.'.italic
+  puts 'Proceeding will package the gem, create a git tag for the version, ' \
+       'push commits and tags to GitHub, and push the .gem file to rubygems.org.'.italic
   puts 'We do not currently have an accessible team account on rubygems.org, so this final step can be skipped.'.italic
   puts
   print 'Proceed [y/N] > '


### PR DESCRIPTION
Update preflight checks to automate release

#### Changes proposed in this pull request

- Update release instructions
- Make release requirements clearer in rakefile
- Make release process clearer in rakefile
- Add formatting for clarity

Output:
```sh
$ bundle exec rake release
```

<img width="1004" height="336" alt="Screenshot 2026-05-06 at 16 29 28" src="https://github.com/user-attachments/assets/57408319-6dcb-404f-9e78-611626a06552" />


**NOTE**:
Due to how the `bundler` rake release task works, these are actually pre-release checks, with the actual release process happening as soon as the task exits. The release process itself is handled by bundler.


#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
